### PR TITLE
Reset src files when resetting the src-overwrite

### DIFF
--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -2,9 +2,7 @@ name: Tests
 on:
   push:
     branches:
-      - master
       - main
-      - track/**
 
 jobs:
   run-tests:
@@ -16,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ run-tests ]
     steps:
-      - name: Upload Charm to Charmhub
+      - name: Checkout
         uses: actions/checkout@v4
       - name: Upload Charm to Charmhub
         uses: canonical/charming-actions/upload-charm@2.4.0

--- a/src/any_charm_base.py
+++ b/src/any_charm_base.py
@@ -7,16 +7,15 @@ import json
 import logging
 from typing import Iterator
 
+import ops
 import yaml
-from ops.charm import ActionEvent, CharmBase
-from ops.model import ActiveStatus, Relation
 
 logger = logging.getLogger(__name__)
 
 __all__ = ["AnyCharmBase"]
 
 
-class AnyCharmBase(CharmBase):
+class AnyCharmBase(ops.CharmBase):
     """Charm the service."""
 
     def __init__(self, *args):
@@ -29,14 +28,14 @@ class AnyCharmBase(CharmBase):
         self.framework.observe(self.on.start, self._on_start_)
 
     def _on_start_(self, event):
-        self.unit.status = ActiveStatus()
+        self.unit.status = ops.ActiveStatus()
 
-    def __relation_iter(self) -> Iterator[Relation]:
+    def __relation_iter(self) -> Iterator[ops.Relation]:
         for relation_name in self.__relations:
             for relation in self.model.relations[relation_name]:
                 yield relation
 
-    def __extrack_relation_unit_data(self, relation: Relation):
+    def __extrack_relation_unit_data(self, relation: ops.Relation):
         data = {}
         for unit in relation.units:
             data[unit.name] = dict(relation.data[unit])
@@ -66,7 +65,7 @@ class AnyCharmBase(CharmBase):
             logger.exception("error while handling get-relation-data action")
             event.fail(repr(exc))
 
-    def _rpc_(self, event: ActionEvent):
+    def _rpc_(self, event: ops.ActionEvent):
         try:
             action_params = event.params
             method = action_params["method"]

--- a/src/charm.py
+++ b/src/charm.py
@@ -4,6 +4,7 @@
 
 """any-charm entrypoint."""
 
+import ast
 import logging
 import os
 import pathlib
@@ -14,15 +15,54 @@ from charmhelpers.core import hookenv
 from ops.main import main
 
 SRC_PATH = pathlib.Path(os.path.abspath(os.path.split(__file__)[0]))
+THIS_FILE = pathlib.Path(__file__)
 
 logger = logging.getLogger(__name__)
 
-for src_overwrite_filename, src_overwrite_file_content in yaml.safe_load(
-    hookenv.config("src-overwrite")
-).items():
-    if src_overwrite_filename == "charm.py":
-        continue
+original = {}
+
+if not original:
+    source = THIS_FILE.read_text(encoding="utf-8")
+    root = ast.parse(source)
+    source_lines = source.splitlines(keepends=True)
+    for stmt in ast.iter_child_nodes(root):
+        if not (
+            isinstance(stmt, ast.Assign)
+            and len(stmt.targets) == 1
+            and isinstance(stmt.targets[0], ast.Name)
+            and stmt.targets[0].id == "original"
+        ):
+            continue
+        value = stmt.value
+        original = {
+            str(f.relative_to(SRC_PATH)): f.read_text(encoding="utf-8")
+            for f in SRC_PATH.iterdir()
+            if not f.samefile(THIS_FILE)
+        }
+        start_offset = (
+            sum(len(line) for line in source_lines[: value.lineno - 1]) + value.col_offset
+        )
+        end_offset = (
+            sum(len(line) for line in source_lines[: value.end_lineno - 1]) + value.end_col_offset
+        )
+        new_source = source[:start_offset]
+        new_source += "{\n"
+        for k, v in original.items():
+            new_source += f"    {repr(k)}: {repr(v)},\n"
+        new_source += "}"
+        new_source += source[end_offset:]
+        THIS_FILE.write_text(new_source, encoding="utf-8")
+        break
+    else:
+        raise RuntimeError("failed to collect original src files")
+
+for src_overwrite_filename, src_overwrite_file_content in {
+    **original,
+    **yaml.safe_load(hookenv.config("src-overwrite")),
+}.items():
     overwrite_path = SRC_PATH / src_overwrite_filename
+    if overwrite_path.exists() and THIS_FILE.samefile(overwrite_path):
+        continue
     overwrite_path.parent.mkdir(exist_ok=True)
     overwrite_path.write_text(src_overwrite_file_content)
 


### PR DESCRIPTION
When the `src-overwrite` configuration is reset, files in the `src/` directory can be restored to their original state as provided by any-charm. This restoration is made possible through the use of the self-modifying `charm.py` to store the original source files.