### PR TITLE
Fix integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,5 +35,6 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
+          channel: 1.29-strict/stable
       - name: Run integration tests
         run: tox -e integration


### PR DESCRIPTION
The default version of juju has changed to juju 3 and requires a strictly confined microk8s. Update the integration test workflow to satisfy that.