### PR TITLE
Upgrade pydantic to v2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ops
 charmhelpers
-pydantic == 1.10.11
+pydantic ~= 2.0


### PR DESCRIPTION
Temporarily upgrade pre-installed `pydantic` to v2 before we have a solution for installing Python dependencies.