### PR TITLE
feat: add sdcore-nms-k8s relations to any_charm

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -18,9 +18,9 @@ provides:
     interface: matrix_auth
   provide-logging:
     interface: loki_push_api
-  sdcore_config:
+  provide-sdcore-config:
     interface: sdcore_config
-  fiveg_core_gnb:
+  provide-fiveg-core-gnb:
     interface: fiveg_core_gnb
 
 peers:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -18,6 +18,10 @@ provides:
     interface: matrix_auth
   provide-logging:
     interface: loki_push_api
+  sdcore_config:
+    interface: sdcore_config
+  fiveg_core_gnb:
+    interface: fiveg_core_gnb
 
 peers:
   peer-any:


### PR DESCRIPTION
This PR adds the relations of [sdcore-nms-k8s-operator](https://github.com/canonical/sdcore-nms-k8s-operator/tree/main) to the `any_charm` to be able to use them during integration tests.