### PR TITLE
feat: add fiveg_n2 relation to any_charm

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -22,6 +22,8 @@ provides:
     interface: sdcore_config
   provide-fiveg-core-gnb:
     interface: fiveg_core_gnb
+  provide-fiveg-n2:
+    interface: fiveg_n2
 
 peers:
   peer-any:


### PR DESCRIPTION
This PR adds the fiveg_n2 relation to the any_charm to be able to use them during integration tests.