### PR TITLE
Add missing CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @canonical/is-charms


### PR DESCRIPTION
All repos owned by IS-charms should contain the CODEOWNERS file.