### PR TITLE
chore(ci): add actions:read and contents:write permissions to publish workflows (charmkeeper)

### DIFF
--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -2,7 +2,7 @@ name: Tests
 on:
   push:
     branches:
-      - main
+    - main
 
 jobs:
   run-tests:
@@ -11,84 +11,90 @@ jobs:
 
   publish-any-charm:
     name: Publish any-charm ${{ matrix.arch }} Ubuntu ${{ matrix.ubuntu-version }}
+    permissions:
+      actions: read
+      contents: write
     runs-on: ${{ matrix.runs-on }}
     needs: [run-tests]
     strategy:
       matrix:
         include:
-          - arch: amd64
-            ubuntu-version: "22.04"
-            runs-on: ubuntu-22.04
-          - arch: arm64
-            ubuntu-version: "22.04"
-            runs-on: [self-hosted, arm64, jammy]
-          - arch: amd64
-            ubuntu-version: "24.04"
-            runs-on: ubuntu-24.04
-          - arch: arm64
-            ubuntu-version: "24.04"
-            runs-on: [self-hosted, arm64, noble]
-          - arch: ppc64el
-            ubuntu-version: "24.04"
-            runs-on: [self-hosted, ppc64el, noble]
-          - arch: s390x
-            ubuntu-version: "24.04"
-            runs-on: [self-hosted, s390x, noble]
+        - arch: amd64
+          ubuntu-version: "22.04"
+          runs-on: ubuntu-22.04
+        - arch: arm64
+          ubuntu-version: "22.04"
+          runs-on: [self-hosted, arm64, jammy]
+        - arch: amd64
+          ubuntu-version: "24.04"
+          runs-on: ubuntu-24.04
+        - arch: arm64
+          ubuntu-version: "24.04"
+          runs-on: [self-hosted, arm64, noble]
+        - arch: ppc64el
+          ubuntu-version: "24.04"
+          runs-on: [self-hosted, ppc64el, noble]
+        - arch: s390x
+          ubuntu-version: "24.04"
+          runs-on: [self-hosted, s390x, noble]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - uses: canonical/setup-lxd@main
-        with:
-          channel: 5.21/stable
-      - name: Upload Charm to Charmhub
-        uses: canonical/charming-actions/upload-charm@2.7.0
-        with:
-          credentials: ${{ secrets.CHARMHUB_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          channel: latest/beta
-          destructive-mode: false
+    - name: Checkout
+      uses: actions/checkout@v6
+    - uses: canonical/setup-lxd@main
+      with:
+        channel: 5.21/stable
+    - name: Upload Charm to Charmhub
+      uses: canonical/charming-actions/upload-charm@2.7.0
+      with:
+        credentials: ${{ secrets.CHARMHUB_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        channel: latest/beta
+        destructive-mode: false
 
   publish-any-charm-k8s:
     name: Publish any-charm-k8s ${{ matrix.arch }} Ubuntu ${{ matrix.ubuntu-version }}
+    permissions:
+      actions: read
+      contents: write
     runs-on: ${{ matrix.runs-on }}
     needs: [run-tests]
     strategy:
       matrix:
         include:
-          - arch: amd64
-            ubuntu-version: "22.04"
-            runs-on: ubuntu-22.04
-          - arch: arm64
-            ubuntu-version: "22.04"
-            runs-on: [self-hosted, arm64, jammy]
-          - arch: amd64
-            ubuntu-version: "24.04"
-            runs-on: ubuntu-24.04
-          - arch: arm64
-            ubuntu-version: "24.04"
-            runs-on: [self-hosted, arm64, noble]
+        - arch: amd64
+          ubuntu-version: "22.04"
+          runs-on: ubuntu-22.04
+        - arch: arm64
+          ubuntu-version: "22.04"
+          runs-on: [self-hosted, arm64, jammy]
+        - arch: amd64
+          ubuntu-version: "24.04"
+          runs-on: ubuntu-24.04
+        - arch: arm64
+          ubuntu-version: "24.04"
+          runs-on: [self-hosted, arm64, noble]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - uses: canonical/setup-lxd@main
-        with:
-          channel: 5.21/stable
-      - name: Update metadata.yaml
-        run: |
-          yq eval '.name = "any-charm-k8s"' --inplace metadata.yaml
-          yq eval '.containers = {"any": {"resource": "any-image"}}' --inplace metadata.yaml
-          yq eval '.resources = {
-            "any-image": {
-              "type": "oci-image",
-              "description": "Any OCI image",
-              "upstream-source": "ubuntu:latest"
-            }
-          }' --inplace metadata.yaml
-      - name: Upload Charm to Charmhub
-        uses: canonical/charming-actions/upload-charm@2.7.0
-        with:
-          credentials: ${{ secrets.CHARMHUB_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          channel: latest/beta
-          tag-prefix: any-charm-k8s
-          destructive-mode: false
+    - name: Checkout
+      uses: actions/checkout@v6
+    - uses: canonical/setup-lxd@main
+      with:
+        channel: 5.21/stable
+    - name: Update metadata.yaml
+      run: |
+        yq eval '.name = "any-charm-k8s"' --inplace metadata.yaml
+        yq eval '.containers = {"any": {"resource": "any-image"}}' --inplace metadata.yaml
+        yq eval '.resources = {
+          "any-image": {
+            "type": "oci-image",
+            "description": "Any OCI image",
+            "upstream-source": "ubuntu:latest"
+          }
+        }' --inplace metadata.yaml
+    - name: Upload Charm to Charmhub
+      uses: canonical/charming-actions/upload-charm@2.7.0
+      with:
+        credentials: ${{ secrets.CHARMHUB_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        channel: latest/beta
+        tag-prefix: any-charm-k8s
+        destructive-mode: false


### PR DESCRIPTION
This PR adds `actions: read` and `contents: write` permissions to GitHub Actions jobs that use the `canonical/operator-workflows/.github/workflows/publish_charm.yaml` reusable workflow or `canonical/charming-actions/upload-charm` action.
These permissions are required for the workflow to function correctly with the latest changes to the reusable workflow.