### PR TITLE
feat: add provide-debug-ssh endpoint

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -111,6 +111,8 @@ provides:
     interface: db
   provide-db2:
     interface: db2
+  provide-debug-ssh:
+    interface: debug-ssh
   provide-designate:
     interface: designate
   provide-dex-oidc-config:


### PR DESCRIPTION
Add `provide-debug-ssh` (interface: `debug-ssh`) to the provides list in alphabetical order, consistent with the other endpoints in this file.

This endpoint is needed by GARM charm integration tests in [canonical/github-runner-operators](https://github.com/canonical/github-runner-operators) to fake a tmate debug-ssh provider using any-charm's `src-overwrite` mechanism. Without it, `self.on['provide-debug-ssh'].relation_joined` raises `AttributeError` at charm startup since the relation is not registered in the charm's metadata.