### PR TITLE
bump microk8s to 1.35-strict/stable, pin cryptography, and disable fail-fast

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
         with:
           juju-channel: 3.6/stable
           provider: microk8s
-          channel: 1.29-strict/stable
+          channel: 1.32-strict/stable
       - name: Run integration tests
         run: tox -e integration -- -k ${{ matrix.module }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,9 +34,9 @@ jobs:
         module: [test_charm, test_demo, test_packages]
         include:
           - ubuntu-version: "22.04"
-            microk8s-channel: "1.32-strict/stable"
+            microk8s-channel: "1.35-strict/stable"
           - ubuntu-version: "24.04"
-            microk8s-channel: "1.33-strict/stable"
+            microk8s-channel: "1.35-strict/stable"
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
         with:
           juju-channel: 3.6/stable
           provider: microk8s
-          channel: 1.32-strict/stable
+          channel: 1.32/stable
       - name: Run integration tests
         run: tox -e integration -- -k ${{ matrix.module }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,11 @@ jobs:
       matrix:
         ubuntu-version: ["22.04", "24.04"]
         module: [test_charm, test_demo, test_packages]
+        include:
+          - ubuntu-version: "22.04"
+            microk8s-channel: "1.32-strict/stable"
+          - ubuntu-version: "24.04"
+            microk8s-channel: "1.33-strict/stable"
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -40,7 +45,7 @@ jobs:
         with:
           juju-channel: 3.6/stable
           provider: microk8s
-          channel: 1.32/stable
+          channel: ${{ matrix.microk8s-channel }}
       - name: Run integration tests
         run: tox -e integration -- -k ${{ matrix.module }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,7 @@ jobs:
     name: Integration tests (microk8s) ${{ matrix.ubuntu-version }}
     runs-on: ubuntu-${{ matrix.ubuntu-version }}
     strategy:
+      fail-fast: false
       matrix:
         ubuntu-version: ["22.04", "24.04"]
         module: [test_charm, test_demo, test_packages]
@@ -49,6 +50,7 @@ jobs:
     runs-on:
       [self-hosted, "${{ matrix.arch }}", "${{ matrix.ubuntu-codename }}"]
     strategy:
+      fail-fast: false
       matrix:
         arch: [s390x, arm64, ppc64le, amd64]
         ubuntu-version: ["22.04", "24.04"]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,11 +32,6 @@ jobs:
       matrix:
         ubuntu-version: ["22.04", "24.04"]
         module: [test_charm, test_demo, test_packages]
-        include:
-          - ubuntu-version: "22.04"
-            microk8s-channel: "1.35-strict/stable"
-          - ubuntu-version: "24.04"
-            microk8s-channel: "1.35-strict/stable"
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -45,7 +40,7 @@ jobs:
         with:
           juju-channel: 3.6/stable
           provider: microk8s
-          channel: ${{ matrix.microk8s-channel }}
+          channel: 1.35-strict/stable
       - name: Run integration tests
         run: tox -e integration -- -k ${{ matrix.module }}
 

--- a/tox.ini
+++ b/tox.ini
@@ -69,9 +69,13 @@ commands =
 description = Run integration tests
 deps =
     juju==3.6.0.0
-    # 2025/11/06 Pin protobuf due to issues with S390x architecture issues. See: 
+    # 2025/11/06 Pin protobuf due to issues with S390x architecture issues. See:
     # https://github.com/protocolbuffers/protobuf/issues/24103
     protobuf==6.32.1
+    # 2026/06/25 Pin cryptography due to Cargo.lock v4 compatibility issues on S390x/ppc64le.
+    # Newer cryptography versions ship Cargo.lock v4, which requires Rust >=1.87, but the
+    # self-hosted runners use an older Rust toolchain that cannot parse it.
+    cryptography==44.0.2
     pytest
     pytest-operator
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
### `.github/workflows/ci.yaml`
- **Bump microk8s channel** from `1.29-strict/stable` to `1.35-strict/stable` in the `integration-test-microk8s` job
- **Remove redundant matrix `include` entries** — both Ubuntu versions mapped to the same `microk8s-channel` value; the channel is now set directly in the step
- **Add `fail-fast: false`** to both `integration-test-microk8s` and `integration-test-lxd` strategy blocks so a single failing combination does not cancel the remaining matrix runs

### `tox.ini`
- **Pin `cryptography==44.0.2`** — newer versions ship a Cargo.lock v4 file that requires Rust ≥ 1.87, which is not available on the S390x/ppc64le self-hosted runners